### PR TITLE
Handle malformed inputs given via the CLI more gracefully

### DIFF
--- a/pkilint/bin/lint_pkix_cert.py
+++ b/pkilint/bin/lint_pkix_cert.py
@@ -44,7 +44,11 @@ def main(cli_args=None) -> int:
 
         return 0
     else:
-        cert = loader.load_certificate(args.file, args.file.name)
+        try:
+            cert = loader.load_certificate(args.file, args.file.name)
+        except ValueError as e:
+            print(f'Failed to load certificate: {e}')
+            return 1
 
         results = doc_validator.validate(cert.root)
 


### PR DESCRIPTION
Instead of crashing and exposing the traceback of pyasn1 internals, show an error message. This can help differentiate an error inside pkilint from an error inside the input data.