### PR TITLE
Support loading of PEM-encoded OCSP Responses

### DIFF
--- a/pkilint/loader.py
+++ b/pkilint/loader.py
@@ -20,11 +20,13 @@ def _create_pem_re(ascii_armor=('', '')) -> re.Pattern:
 
 _CERTIFICATE_PEM_REGEX = _create_pem_re(_create_ascii_armor('CERTIFICATE'))
 _CRL_PEM_REGEX = _create_pem_re(_create_ascii_armor('X509 CRL'))
+_OCSPRESPONSE_PEM_REGEX = _create_pem_re(_create_ascii_armor('OCSP RESPONSE'))
 _GENERIC_BASE64_REGEX = _create_pem_re()
 
 _DOCUMENT_CLS_TO_PEM_REGEX = {
     RFC5280Certificate: _CERTIFICATE_PEM_REGEX,
     RFC5280CertificateList: _CRL_PEM_REGEX,
+    RFC6960OCSPResponse: _OCSPRESPONSE_PEM_REGEX,
 }
 
 


### PR DESCRIPTION
I'm looking for a way to lint PEM-encoded OCSP Responses, which pkilint currently rejects.

A [quick search](https://www.google.com/search?q=%22-----BEGIN+OCSP+RESPONSE-----%22) suggests that `-----BEGIN OCSP RESPONSE-----` and `-----END OCSP RESPONSE-----` are used by several other projects.

@CBonnell I realise that [RFC7468 Section 4](https://datatracker.ietf.org/doc/html/rfc7468#section-4) doesn't define a standard PEM encapsulation boundary for OCSP responses, but would you be willing to accept this PR anyway?