### PR TITLE
Use correct boolean variable in two places.

### DIFF
--- a/pkilint/etsi/__init__.py
+++ b/pkilint/etsi/__init__.py
@@ -97,7 +97,7 @@ def determine_certificate_type(cert: certificate.RFC5280Certificate) -> Certific
                     )
                 else:
                     return (
-                        CertificateType.NCP_W_NATURAL_PERSON_PRE_CERTIFICATE if is_webauth
+                        CertificateType.NCP_W_NATURAL_PERSON_PRE_CERTIFICATE if is_precert
                         else CertificateType.NCP_W_NATURAL_PERSON_FINAL_CERTIFICATE
                     )
 
@@ -116,7 +116,7 @@ def determine_certificate_type(cert: certificate.RFC5280Certificate) -> Certific
                     )
                 else:
                     return (
-                        CertificateType.NCP_W_LEGAL_PERSON_PRE_CERTIFICATE if is_webauth
+                        CertificateType.NCP_W_LEGAL_PERSON_PRE_CERTIFICATE if is_precert
                         else CertificateType.NCP_W_LEGAL_PERSON_FINAL_CERTIFICATE
                     )
 


### PR DESCRIPTION
Hi @CBonnell. I noticed this whilst mirroring your ETSI certificate type detection logic in [this pkimetal commit](https://github.com/pkimetal/pkimetal/commit/3d1264c6755e5bfcff15920ba094ade0bf4a7f99) just now.