### PR TITLE
Insert missing source field for S/MIME pkix.smtp_utf8_mailbox_domain_part_invalid_syntax

### DIFF
--- a/pkilint/cabf/smime/finding_metadata.csv
+++ b/pkilint/cabf/smime/finding_metadata.csv
@@ -109,7 +109,7 @@ ERROR,pkix.rfc6818_certificate_policies_invalid_explicit_text_encoding,RFC 6818 
 ERROR,pkix.san_extension_not_critical,RFC 5280 4.2.1.6,"""If the subject field contains an empty sequence, then the issuing CA MUST include a subjectAltName extension that is marked as critical"""
 ERROR,pkix.sct_list_empty,"RFC 6962 3.3: ""At least one SCT MUST be included""",
 ERROR,pkix.smime_capabilities_extension_critical,RFC 4262 2,"""This extension MUST NOT be marked critical."""
-ERROR,pkix.smtp_utf8_mailbox_domain_part_invalid_syntax,"RFC 9598, section 3: "". In SmtpUTF8Mailbox, labels that include non-ASCII characters MUST be stored in A-label (rather than U-label) form [RFC5890]."""
+ERROR,pkix.smtp_utf8_mailbox_domain_part_invalid_syntax,RFC 9598 3,"""In SmtpUTF8Mailbox, labels that include non-ASCII characters MUST be stored in A-label (rather than U-label) form [RFC5890]."""
 ERROR,pkix.smtp_utf8_mailbox_has_bom,RFC 8398 3,"""The UTF8String encoding MUST NOT contain a Byte-Order-Mark (BOM) [RFC3629] to aid consistency across implementations, particularly for comparison."""
 ERROR,pkix.smtp_utf8_mailbox_has_uppercase,RFC 8398 3,"""In SmtpUTF8Mailbox, domain labels that solely use ASCII characters (meaning neither A- nor U-labels) SHALL use NR-LDH restrictions as specified by Section 2.3.1 of [RFC5890] and SHALL be restricted to lowercase letters."""
 ERROR,pkix.smtp_utf8_mailbox_invalid_syntax,RFC 8398 3,"Value does not contain ""@"""


### PR DESCRIPTION
Hi @CBonnell.  I suspect this was a copy'n'paste error in a recent commit.  Do you have any plans to make the columns in the CSV files consistent?

Currently only the S/MIME one has a "source" column...
``` bash
> find . -iname "*.csv" -print -exec head -n 1 '{}' ';'
./cabf/smime/finding_metadata.csv
severity,code,source,description
./cabf/serverauth/finding_metadata.csv
severity,code,description
./etsi/finding_metadata.csv
severity,code,description
```