### PR TITLE
Fix policy OID definitions for DVCP, OVCP, and IVCP in EN 319 411-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project from version 0.9.3 onwards are documented in
 ### Fixes
 
 - Remove extraneous ".1" component from policy OID arc in the ASN.1 module for EN 319 411-1 (#151)
+- Fix OIDs for DVCP, OVCP, and IVCP in the ASN.1 module for EN 319 411-1 (#154)
 
 ## 0.12.7 - 2025-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project from version 0.9.3 onwards are documented in this file.
 
-## 0.12.8 - 2025-04-XX
+## 0.12.8 - 2025-04-07
 
 ### Fixes
 

--- a/pkilint/etsi/asn1/en_319_411_1.py
+++ b/pkilint/etsi/asn1/en_319_411_1.py
@@ -11,11 +11,11 @@ id_lcp = _ARC + (3,)
 
 id_evcp = _ARC + (4,)
 
-id_dvcp = _ARC + (5,)
+id_dvcp = _ARC + (6,)
 
-id_ovcp = _ARC + (6,)
+id_ovcp = _ARC + (7,)
 
-id_ivcp = _ARC + (7,)
+id_ivcp = _ARC + (8,)
 
 POLICY_OIDS = {
     id_ncp,

--- a/tests/integration_certificate/etsi/qncp_w_ov_eidas_pre_certificate/bad_bc_extension_encoding.crttest
+++ b/tests/integration_certificate/etsi/qncp_w_ov_eidas_pre_certificate/bad_bc_extension_encoding.crttest
@@ -54,7 +54,6 @@ certificate.tbsCertificate.extensions.1.extnValue.subjectKeyIdentifier,SubjectKe
 certificate.tbsCertificate.extensions.2.extnValue.keyUsage,SubscriberKeyUsageValidator,WARNING,cabf.serverauth.subscriber_discouraged_ku_present,Discouraged KU present: dataEncipherment
 certificate.tbsCertificate.extensions.2.extnValue.keyUsage,SubscriberKeyUsageValidator,WARNING,cabf.serverauth.subscriber_rsa_digitalsignature_and_keyencipherment_present,
 certificate.tbsCertificate.extensions.3.extnValue.certificatePolicies,QualifiedCertificatePoliciesValidator,WARNING,etsi.en_319_412_2.qcs-5.2-1.recommended_certificate_type_policy_identifier_missing,"Missing recommended certificate type policy identifier ""0.4.0.194112.1.5"""
-certificate.tbsCertificate.extensions.3.extnValue.certificatePolicies,CertificatePoliciesValidator,ERROR,etsi.en_319_411_1.gen-6.3.3-12.prohibited_reserved_policy_oid_present,Prohibited reserved certificate policy OID present: 0.4.0.2042.1.7
 certificate.tbsCertificate.extensions.3.extnValue.certificatePolicies.2.policyQualifiers.0,CertificatePolicyQualifierValidator,WARNING,cabf.serverauth.certificate_policy_qualifier_present,
 certificate.tbsCertificate.extensions.3.extnValue.certificatePolicies.2.policyQualifiers.1,CertificatePolicyQualifierValidator,WARNING,cabf.serverauth.certificate_policy_qualifier_present,
 certificate.tbsCertificate.extensions.3.extnValue.certificatePolicies.2.policyQualifiers.1,CertificatePolicyQualifierValidator,ERROR,cabf.serverauth.prohibited_certificate_policy_qualifier_type,Prohibited qualifier type: 1.3.6.1.5.5.7.2.2


### PR DESCRIPTION
The ASN.1 module for EN 319 411-1 has incorrect OIDs for DVCP, OVCP, and IVCP. This is due to transcription error likely due to a "hole" in the numbering due to the removal of EVCP+ (.5 is now undefined).