### PR TITLE
Exclude tests from package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,10 @@ install_requires =
     iso4217
     python-iso639 
 
+[options.packages.find]
+exclude =
+    tests*
+
 [options.extras_require]
 rest =
     fastapi


### PR DESCRIPTION
The dist package shouldn't contain the tests as a separate package, otherwise we're dropping a new package in everyone's python path named "tests" (completely independent of pkilint), which can cause conflicts with other projects that have a `tests` package at the root.

Alternatively, we could be explicit about which packages we want to include, instead of using `find:`