### PR TITLE
Align ASN.1 module for EN 319 412-5 with 2025-06 version

### DIFF
--- a/pkilint/etsi/asn1/__init__.py
+++ b/pkilint/etsi/asn1/__init__.py
@@ -11,6 +11,8 @@ ETSI_QC_STATEMENTS_MAPPINGS = {
     en_319_412_5.id_etsi_qcs_QcPDS: en_319_412_5.QcEuPDS(),
     en_319_412_5.id_etsi_qcs_QcType: en_319_412_5.QcType(),
     en_319_412_5.id_etsi_qcs_QcCClegislation: en_319_412_5.QcCClegislation(),
+    en_319_412_5.id_etsi_qcs_QcIdentMethod: en_319_412_5.QcIdentMethod(),
+    en_319_412_5.id_etsi_qcs_QcQSCDlegislation: en_319_412_5.QcQSCDlegislation(),
     ts_119_495.id_etsi_psd2_qcStatement: ts_119_495.PSD2QcType(),
     rfc3739.id_qcs_pkixQCSyntax_v1: document.OptionalAsn1TypeWrapper(
         rfc3739.SemanticsInformation()

--- a/pkilint/etsi/asn1/en_319_412_5.py
+++ b/pkilint/etsi/asn1/en_319_412_5.py
@@ -101,25 +101,61 @@ class QcType(univ.SequenceOf):
 
 
 QcType.componentType = univ.ObjectIdentifier()
+QcType.subtypeSpec = constraint.ValueSizeConstraint(1, 1)
+
+
+class QcIdentMethod(univ.SequenceOf):
+    pass
+
+
+QcIdentMethod.componentType = univ.ObjectIdentifier()
+QcIdentMethod.subtypeSpec = constraint.ValueSizeConstraint(1, 1)
+
+
+class QcQSCDlegislation(univ.SequenceOf):
+    pass
+
+
+QcQSCDlegislation.componentType = CountryName()
+QcQSCDlegislation.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+
 
 id_etsi_qcs = _OID(0, 4, 0, 1862, 1)
 
-id_etsi_qcs_QcCClegislation = _OID(id_etsi_qcs, 7)
+# statement OIDs
 
 id_etsi_qcs_QcCompliance = _OID(id_etsi_qcs, 1)
 
 id_etsi_qcs_QcLimitValue = _OID(id_etsi_qcs, 2)
 
-id_etsi_qcs_QcPDS = _OID(id_etsi_qcs, 5)
-
 id_etsi_qcs_QcRetentionPeriod = _OID(id_etsi_qcs, 3)
 
 id_etsi_qcs_QcSSCD = _OID(id_etsi_qcs, 4)
 
+id_etsi_qcs_QcPDS = _OID(id_etsi_qcs, 5)
+
 id_etsi_qcs_QcType = _OID(id_etsi_qcs, 6)
 
-id_etsi_qct_eseal = _OID(id_etsi_qcs_QcType, 2)
+id_etsi_qcs_QcCClegislation = _OID(id_etsi_qcs, 7)
+
+id_etsi_qcs_QcIdentMethod = _OID(id_etsi_qcs, 8)
+
+id_etsi_qcs_QcQSCDlegislation = _OID(id_etsi_qcs, 9)
+
+# QcType OIDs
 
 id_etsi_qct_esign = _OID(id_etsi_qcs_QcType, 1)
 
+id_etsi_qct_eseal = _OID(id_etsi_qcs_QcType, 2)
+
 id_etsi_qct_web = _OID(id_etsi_qcs_QcType, 3)
+
+# Identification method OIDs
+
+id_etsi_qct_eIDAS1_ab = _OID(id_etsi_qcs_QcIdentMethod, 1)
+
+id_etsi_qct_eIDAS1_cd = _OID(id_etsi_qcs_QcIdentMethod, 2)
+
+id_etsi_qct_eIDAS2_acd = _OID(id_etsi_qcs_QcIdentMethod, 3)
+
+id_etsi_qct_eIDAS2_b = _OID(id_etsi_qcs_QcIdentMethod, 4)

--- a/pkilint/etsi/en_319_412_5.py
+++ b/pkilint/etsi/en_319_412_5.py
@@ -138,22 +138,10 @@ class QcTypeValidator(validation.Validator):
         "etsi.en_319_412_5.gen-4.2.3.qc_type_mismatch",
     )
 
-    VALIDATION_MULTIPLE_QC_TYPE_VALUES_PRESENT = validation.ValidationFinding(
-        validation.ValidationFindingSeverity.ERROR,
-        "etsi.en_319_412_5.gen-4.2.3.multiple_qc_type_values_present",
-    )
-
-    VALIDATION_QC_TYPE_LIST_EMPTY = validation.ValidationFinding(
-        validation.ValidationFindingSeverity.ERROR,
-        "etsi.en_319_412_5.gen-4.2.3.qc_type_list_empty",
-    )
-
     def __init__(self, certificate_type):
         super().__init__(
             validations=[
                 self.VALIDATION_QC_TYPE_MISMATCH,
-                self.VALIDATION_QC_TYPE_LIST_EMPTY,
-                self.VALIDATION_MULTIPLE_QC_TYPE_VALUES_PRESENT,
             ],
             pdu_class=en_319_412_5.QcType,
         )
@@ -168,16 +156,6 @@ class QcTypeValidator(validation.Validator):
             self._expected_qc_type = None
 
     def validate(self, node):
-        if not node.children.values():
-            raise validation.ValidationFindingEncountered(
-                self.VALIDATION_QC_TYPE_LIST_EMPTY
-            )
-
-        if len(node.children.values()) != 1:
-            raise validation.ValidationFindingEncountered(
-                self.VALIDATION_MULTIPLE_QC_TYPE_VALUES_PRESENT
-            )
-
         if self._expected_qc_type:
             _, qctype_value = node.child
 

--- a/tests/integration_certificate/etsi/qevcp_w_non_eidas_pre_certificate/more_than_one_qctype.crttest
+++ b/tests/integration_certificate/etsi/qevcp_w_non_eidas_pre_certificate/more_than_one_qctype.crttest
@@ -43,7 +43,6 @@ Xjzd4Mv+52YQoQ==
 -----END CERTIFICATE-----
 
 node_path,validator,severity,code,message
-certificate.tbsCertificate.extensions.1.extnValue.qCStatements.1.statementInfo.qcType,QcTypeValidator,ERROR,etsi.en_319_412_5.gen-4.2.3.multiple_qc_type_values_present,
 certificate.tbsCertificate.extensions.9.extnValue.subjectKeyIdentifier,SubjectKeyIdentifierValidator,INFO,pkix.subject_key_identifier_method_1_identified,
 certificate.tbsCertificate.subject.rdnSequence,EvSubscriberAttributeAllowanceValidator,WARNING,cabf.ev_guidelines.common_name_attribute_present,
 certificate.tbsCertificate.extensions,SubscriberExtensionAllowanceValidator,WARNING,cabf.serverauth.subscriber.subject_key_identifier_extension_present,
@@ -52,3 +51,4 @@ certificate.tbsCertificate.extensions,SubscriberExtensionAllowanceValidator,WARN
 certificate.tbsCertificate.extensions.3.extnValue.certificatePolicies.3.policyQualifiers.0,CertificatePolicyQualifierValidator,WARNING,cabf.serverauth.certificate_policy_qualifier_present,
 certificate.tbsCertificate.extensions.3.extnValue.certificatePolicies.0.policyQualifiers.0,CertificatePolicyQualifierValidator,WARNING,cabf.serverauth.certificate_policy_qualifier_present,
 certificate.tbsCertificate.extensions,SubscriberExtensionAllowanceValidator,WARNING,cabf.serverauth.subscriber.unknown_extension_present,Unknown extension present: 2.23.140.3.1
+certificate.tbsCertificate.extensions.1.extnValue.qCStatements.1,DecodingValidator,FATAL,itu.invalid_asn1_syntax,"ASN.1 decoding failure occurred at ""certificate.tbsCertificate.extensions.1.extnValue.qCStatements.1.statementInfo"" with schema ""QcType"" corresponding to type OID 0.4.0.1862.1.6: Error decoding ""QcType"" TLV near substrate offset 0: <ValueSizeConstraint object, consts 1, 1> failed at: ValueConstraintError({0: <ObjectIdentifier value object, tagSet <TagSet object, tags 0:0:6>, payload [0.4.0.1862.1.6.3]>, 1: <ObjectIdentifier value object, tagSet <TagSet object, tags 0:0:6>, payload [0.4.0.1862.1.6.1]>})"

--- a/tests/integration_certificate/etsi/qevcp_w_non_eidas_pre_certificate/none_qctype.crttest
+++ b/tests/integration_certificate/etsi/qevcp_w_non_eidas_pre_certificate/none_qctype.crttest
@@ -42,7 +42,6 @@ Eg51Sf1UTQ80xAZJoK8Q3kTzymzUZgqeutUtYrTgXjzd4Mv+52YQoQ==
 -----END CERTIFICATE-----
 
 node_path,validator,severity,code,message
-certificate.tbsCertificate.extensions.1.extnValue.qCStatements.1.statementInfo.qcType,QcTypeValidator,ERROR,etsi.en_319_412_5.gen-4.2.3.qc_type_list_empty,
 certificate.tbsCertificate.extensions.9.extnValue.subjectKeyIdentifier,SubjectKeyIdentifierValidator,INFO,pkix.subject_key_identifier_method_1_identified,
 certificate.tbsCertificate.subject.rdnSequence,EvSubscriberAttributeAllowanceValidator,WARNING,cabf.ev_guidelines.common_name_attribute_present,
 certificate.tbsCertificate.extensions,SubscriberExtensionAllowanceValidator,WARNING,cabf.serverauth.subscriber.subject_key_identifier_extension_present,
@@ -51,3 +50,4 @@ certificate.tbsCertificate.extensions,SubscriberExtensionAllowanceValidator,WARN
 certificate.tbsCertificate.extensions.3.extnValue.certificatePolicies.3.policyQualifiers.0,CertificatePolicyQualifierValidator,WARNING,cabf.serverauth.certificate_policy_qualifier_present,
 certificate.tbsCertificate.extensions.3.extnValue.certificatePolicies.0.policyQualifiers.0,CertificatePolicyQualifierValidator,WARNING,cabf.serverauth.certificate_policy_qualifier_present,
 certificate.tbsCertificate.extensions,SubscriberExtensionAllowanceValidator,WARNING,cabf.serverauth.subscriber.unknown_extension_present,Unknown extension present: 2.23.140.3.1
+certificate.tbsCertificate.extensions.1.extnValue.qCStatements.1,DecodingValidator,FATAL,itu.invalid_asn1_syntax,"ASN.1 decoding failure occurred at ""certificate.tbsCertificate.extensions.1.extnValue.qCStatements.1.statementInfo"" with schema ""QcType"" corresponding to type OID 0.4.0.1862.1.6: Error decoding ""QcType"" TLV near substrate offset 0: <ValueSizeConstraint object, consts 1, 1> failed at: ValueConstraintError({})"


### PR DESCRIPTION
Resolves #194.

Also removed `etsi.en_319_412_5.gen-4.2.3.qc_type_list_empty` and `etsi.en_319_412_5.gen-4.2.3.multiple_qc_type_values_present` validations because the ASN.1 decoder will now enforce thanks to the SIZE constraint.