### PR TITLE
Add ts 119 312 rsa sunset

### DIFF
--- a/pkilint/etsi/__init__.py
+++ b/pkilint/etsi/__init__.py
@@ -289,6 +289,7 @@ def create_validators(
 
     spki_validators = [
         ts_119_312.RsaKeyValidator(),
+        ts_119_312.RsaKeySunsetValidator(),
         ts_119_312.AllowedPublicKeyTypeValidator(),
     ]
 

--- a/pkilint/etsi/ts_119_312.py
+++ b/pkilint/etsi/ts_119_312.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Optional
 
 from pyasn1.codec.der.encoder import encode
@@ -65,6 +66,80 @@ class RsaKeyValidator(validation.Validator):
             )
 
         return validation.ValidationResult(self, node, findings)
+
+
+class RsaKeySunsetValidator(validation.Validator):
+    """
+    TS 119 312, clause 8.4:
+
+    RSA keys with a length of at least 1 900 bits and less than 3 000 bits shall not be used to issue new
+    certificates after 2026-12-31. Certificates based on such keys that were issued on or before 2026-12-31 shall
+    have a validity period ending no later than 2028-12-31. ... After 2026-12-31, only RSA keys with a length of at
+    least 3 000 bits or signature schemes marked as Recommended (R) in the present document shall be used for newly
+    issued certificates.
+
+    Note: the requirement that the same key pair shall not be used to obtain a new certificate after expiry is not
+    checked by this validator, as doing so requires knowledge of other certificates that is not available when
+    linting a single certificate in isolation.
+    """
+
+    VALIDATION_RSA_KEY_SIZE_PROHIBITED_AFTER_SUNSET_DATE = validation.ValidationFinding(
+        validation.ValidationFindingSeverity.ERROR,
+        "ts_119_312.8.4.rsa_key_size_prohibited_after_sunset_date",
+    )
+
+    # Certificates based on such keys that were issued on or before 2026-12-31 shall have a validity period ending no
+    # later than 2028-12-31.
+    VALIDATION_RSA_LEGACY_KEY_VALIDITY_PERIOD_EXCEEDS_END_DATE = (
+        validation.ValidationFinding(
+            validation.ValidationFindingSeverity.ERROR,
+            "ts_119_312.8.4.rsa_legacy_key_validity_period_exceeds_end_date",
+        )
+    )
+
+    _MIN_RECOMMENDED_MODULUS_LENGTH = 3000
+    _LEGACY_MODULUS_LENGTH_LOWER_BOUND = 1900
+    _SUNSET_DATETIME = datetime.datetime(2027, 1, 1, tzinfo=datetime.timezone.utc)
+    _MAXIMUM_VALIDITY_END_DATETIME = datetime.datetime(
+        2029, 1, 1, tzinfo=datetime.timezone.utc
+    )
+
+    def __init__(self):
+        super().__init__(
+            validations=[
+                self.VALIDATION_RSA_KEY_SIZE_PROHIBITED_AFTER_SUNSET_DATE,
+                self.VALIDATION_RSA_LEGACY_KEY_VALIDITY_PERIOD_EXCEEDS_END_DATE,
+            ],
+            pdu_class=rfc3279.RSAPublicKey,
+        )
+
+    def validate(self, node):
+        modulus_len = int(node.children["modulus"].pdu).bit_length()
+
+        if modulus_len >= self._MIN_RECOMMENDED_MODULUS_LENGTH:
+            return
+
+        cert = node.document
+
+        if cert.not_before >= self._SUNSET_DATETIME:
+            raise validation.ValidationFindingEncountered(
+                self.VALIDATION_RSA_KEY_SIZE_PROHIBITED_AFTER_SUNSET_DATE,
+                f"Certificate was issued with a {modulus_len}-bit RSA public key, which is less than the "
+                f"{self._MIN_RECOMMENDED_MODULUS_LENGTH}-bit minimum required for certificates issued "
+                "after 2026-12-31",
+            )
+
+        # certificate was issued on or before the sunset date; if it uses a "legacy" band key (>= 1900 bits),
+        # then its validity period may not extend beyond the 2028-12-31 cap
+        if (
+            modulus_len >= self._LEGACY_MODULUS_LENGTH_LOWER_BOUND
+            and cert.not_after >= self._MAXIMUM_VALIDITY_END_DATETIME
+        ):
+            raise validation.ValidationFindingEncountered(
+                self.VALIDATION_RSA_LEGACY_KEY_VALIDITY_PERIOD_EXCEEDS_END_DATE,
+                f"Certificate uses a {modulus_len}-bit RSA public key and was issued on or before 2026-12-31, "
+                "so its validity period is required to end no later than 2028-12-31",
+            )
 
 
 def _create_alg_id_der(

--- a/tests/etsi/test_ts_119_312.py
+++ b/tests/etsi/test_ts_119_312.py
@@ -1,0 +1,118 @@
+import datetime
+import pytest
+from pyasn1_alt_modules import rfc3279
+from pkilint import document, validation
+from pkilint.etsi import ts_119_312
+
+
+class _StubCertificate:
+    """A minimal stand-in for pkilint.pkix.certificate.RFC5280Certificate that exposes only the
+    attributes required by RsaKeySunsetValidator."""
+
+    def __init__(self, not_before, not_after):
+        self.not_before = not_before
+        self.not_after = not_after
+
+
+def _create_node(modulus_bit_length, not_before, not_after, exponent=65537):
+    # sets the top bit so that the modulus has precisely the specified bit length
+    modulus = 1 << (modulus_bit_length - 1)
+    rsa_public_key = rfc3279.RSAPublicKey()
+    rsa_public_key["modulus"] = modulus
+    rsa_public_key["publicExponent"] = exponent
+    stub_cert = _StubCertificate(not_before, not_after)
+    return document.PDUNode(stub_cert, "rSAPublicKey", rsa_public_key, None)
+
+
+# the last instant at which issuance is still considered "on or before 2026-12-31"
+_BEFORE_SUNSET = datetime.datetime(
+    2026, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc
+)
+# the first instant which is considered "after 2026-12-31"
+_AT_SUNSET = datetime.datetime(2027, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+# the last instant which is still considered "no later than 2028-12-31"
+_BEFORE_MAX_VALIDITY_END = datetime.datetime(
+    2028, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc
+)
+# the first instant which is no longer considered "no later than 2028-12-31"
+_AT_MAX_VALIDITY_END = datetime.datetime(
+    2029, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+)
+
+
+def test_large_key_is_always_permitted():
+    validator = ts_119_312.RsaKeySunsetValidator()
+    node = _create_node(3000, _AT_SUNSET, _AT_MAX_VALIDITY_END)
+    assert validator.match(node)
+    assert validator.validate(node) is None
+
+
+def test_legacy_key_compliant_with_sunset_and_end_date_is_permitted():
+    validator = ts_119_312.RsaKeySunsetValidator()
+    node = _create_node(2048, _BEFORE_SUNSET, _BEFORE_MAX_VALIDITY_END)
+    assert validator.validate(node) is None
+
+
+def test_legacy_key_issued_after_sunset_date_is_prohibited():
+    validator = ts_119_312.RsaKeySunsetValidator()
+    node = _create_node(2048, _AT_SUNSET, _BEFORE_MAX_VALIDITY_END)
+    with pytest.raises(validation.ValidationFindingEncountered) as e:
+        validator.validate(node)
+    assert (
+        e.value.finding
+        == validator.VALIDATION_RSA_KEY_SIZE_PROHIBITED_AFTER_SUNSET_DATE
+    )
+
+
+def test_small_key_issued_after_sunset_date_is_prohibited():
+    validator = ts_119_312.RsaKeySunsetValidator()
+    # a modulus below the 1 900-bit "legacy" band is also prohibited after the sunset date, per the broader
+    # "only RSA keys with a length of at least 3 000 bits ... shall be used" requirement
+    node = _create_node(1024, _AT_SUNSET, _BEFORE_MAX_VALIDITY_END)
+    with pytest.raises(validation.ValidationFindingEncountered) as e:
+        validator.validate(node)
+    assert (
+        e.value.finding
+        == validator.VALIDATION_RSA_KEY_SIZE_PROHIBITED_AFTER_SUNSET_DATE
+    )
+
+
+def test_modulus_length_boundary_2999_bits_is_subject_to_sunset_date():
+    validator = ts_119_312.RsaKeySunsetValidator()
+    node = _create_node(2999, _AT_SUNSET, _BEFORE_MAX_VALIDITY_END)
+    with pytest.raises(validation.ValidationFindingEncountered) as e:
+        validator.validate(node)
+    assert (
+        e.value.finding
+        == validator.VALIDATION_RSA_KEY_SIZE_PROHIBITED_AFTER_SUNSET_DATE
+    )
+
+
+def test_legacy_key_validity_period_exceeds_end_date_is_prohibited():
+    validator = ts_119_312.RsaKeySunsetValidator()
+    node = _create_node(2048, _BEFORE_SUNSET, _AT_MAX_VALIDITY_END)
+    with pytest.raises(validation.ValidationFindingEncountered) as e:
+        validator.validate(node)
+    assert (
+        e.value.finding
+        == validator.VALIDATION_RSA_LEGACY_KEY_VALIDITY_PERIOD_EXCEEDS_END_DATE
+    )
+
+
+def test_modulus_length_boundary_1900_bits_is_subject_to_end_date_cap():
+    validator = ts_119_312.RsaKeySunsetValidator()
+    node = _create_node(1900, _BEFORE_SUNSET, _AT_MAX_VALIDITY_END)
+    with pytest.raises(validation.ValidationFindingEncountered) as e:
+        validator.validate(node)
+    assert (
+        e.value.finding
+        == validator.VALIDATION_RSA_LEGACY_KEY_VALIDITY_PERIOD_EXCEEDS_END_DATE
+    )
+
+
+def test_small_key_issued_before_sunset_date_is_not_subject_to_end_date_cap():
+    validator = ts_119_312.RsaKeySunsetValidator()
+    # the validity period end date cap is scoped to keys within the 1 900-2 999 bit "legacy" band; smaller keys
+    # are out of scope for this specific validator (a separate, pre-existing validator flags small moduli generally)
+    node = _create_node(1899, _BEFORE_SUNSET, _AT_MAX_VALIDITY_END)
+    assert validator.validate(node) is None


### PR DESCRIPTION
Add validator for new RSA >1900 <3000 sunset for ETSI certificates. Reference from ts 119 312
> RSA keys with a length of at least 1 900 bits and less than 3 000 bits shall not be used to issue new certificates after
> 2026-12-31. Certificates based on such keys that were issued on or before 2026-12-31 shall have a validity period
> ending no later than 2028-12-31. The same key pair shall not be used to obtain a new certificate after expiry, regardless
> of the cryptographic parameters of that new certificate. After 2026-12-31, only RSA keys with a length of at least
> 3 000 bits or signature schemes marked as Recommended (R) in the present document shall be used for newly issued
> certificates.